### PR TITLE
Make user profile request to testeb-api/productizer, instead of calli…

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -31,6 +31,7 @@ jobs:
         env:
           REACT_APP_AUTH_GW_BASE_URL: ${{ secrets.REACT_APP_AUTH_GW_BASE_URL }}
           REACT_APP_USER_API_BASE_URL: ${{ secrets.REACT_APP_USER_API_BASE_URL }}
+          REACT_APP_TESTBED_API_BASE_URL: ${{ secrets.REACT_APP_TESTBED_API_BASE_URL }}
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { isPast, parseISO } from 'date-fns';
 
 // endpoints
-import { USER_API_BASE_URL } from './endpoints';
+import { USER_API_BASE_URL, TESTBED_API_BASE_URL } from './endpoints';
 
 // constants
 import {
@@ -26,6 +26,10 @@ const USER_API_URLS = [
   `${USER_API_BASE_URL}/code-sets/languages`,
 ];
 
+const TESTBED_API_URLS = [
+  `${TESTBED_API_BASE_URL}/testbed/productizers/user-profile`,
+];
+
 // Axios request interceptor. Pass token to request Authorization for selected routes, if found.
 axiosInstance.interceptors.request.use(config => {
   const loggedInState = JSONSessionStorage.get(SESSION_STORAGE_AUTH_TOKENS);
@@ -33,7 +37,7 @@ axiosInstance.interceptors.request.use(config => {
   if (config.url !== undefined && config.headers !== undefined) {
     if (loggedInState) {
       // pass id token for all user api calls
-      if (USER_API_URLS.includes(config.url)) {
+      if ([...USER_API_URLS, ...TESTBED_API_URLS].includes(config.url)) {
         const idToken = loggedInState.idToken;
         config.headers.Authorization = idToken ? `Bearer ${idToken}` : '';
       }

--- a/src/api/endpoints/index.ts
+++ b/src/api/endpoints/index.ts
@@ -4,3 +4,7 @@ export const AUTH_GW_BASE_URL =
 
 export const USER_API_BASE_URL =
   process.env.REACT_APP_USER_API_BASE_URL || 'http://localhost:5001';
+
+export const TESTBED_API_BASE_URL =
+  process.env.REACT_APP_TESTBED_API_BASE_URL ||
+  'https://v2xw5b7nhqkduxcw6v56pas5yy0livjb.lambda-url.eu-north-1.on.aws';

--- a/src/api/services/user.ts
+++ b/src/api/services/user.ts
@@ -4,14 +4,17 @@ import axiosInstance from '../axiosInstance';
 import { UserProfile } from '../../@types';
 
 // endpoints
-import { USER_API_BASE_URL } from '../endpoints';
+import { USER_API_BASE_URL, TESTBED_API_BASE_URL } from '../endpoints';
 
 export async function verify() {
   return axiosInstance.get(`${USER_API_BASE_URL}/identity/verify`);
 }
 
+// testbed-api / productizer call
 export async function get() {
-  return axiosInstance.get(`${USER_API_BASE_URL}/user`);
+  return axiosInstance.post(
+    `${TESTBED_API_BASE_URL}/testbed/productizers/user-profile`
+  );
 }
 
 export async function getConsents() {

--- a/src/components/Registration/Registration.tsx
+++ b/src/components/Registration/Registration.tsx
@@ -42,8 +42,9 @@ export default function Registration() {
     setProfileLoading(true);
 
     try {
-      const response = await api.user.patch({ immigrationDataConsent });
-      setUserProfile(response.data);
+      await api.user.patch({ immigrationDataConsent });
+      const userProfileResponse = await api.user.get();
+      setUserProfile(userProfileResponse.data);
 
       if (immigrationDataConsent) {
         setProfileDataUsed(true);

--- a/src/testing/mocks/handlers.ts
+++ b/src/testing/mocks/handlers.ts
@@ -1,7 +1,11 @@
 import { rest } from 'msw';
 
 // endpoints
-import { AUTH_GW_BASE_URL, USER_API_BASE_URL } from '../../api/endpoints';
+import {
+  AUTH_GW_BASE_URL,
+  USER_API_BASE_URL,
+  TESTBED_API_BASE_URL,
+} from '../../api/endpoints';
 
 const mockAuthUser = {
   idToken: 'test-token',
@@ -59,9 +63,12 @@ export const handlers = [
       })
     );
   }),
-  rest.get(`${USER_API_BASE_URL}/user`, (req, res, ctx) => {
-    return res(ctx.json(mockUser));
-  }),
+  rest.post(
+    `${TESTBED_API_BASE_URL}/testbed/productizers/user-profile`,
+    (req, res, ctx) => {
+      return res(ctx.json(mockUser));
+    }
+  ),
   rest.get(`${USER_API_BASE_URL}/user/consents`, (req, res, ctx) => {
     return res(ctx.json({ immigrationDataConsent: true }));
   }),


### PR DESCRIPTION
Changed user profile calls to go trough testbed-api/productizer. Can't be merged before we have this working correctly, still some fine-tuning in testbed-api/productizer end.