### PR TITLE
build: tag a release from deployment to the staging env

### DIFF
--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -104,3 +104,9 @@ jobs:
       - name: Run Pulumi deployment
         working-directory: ./infra
         run: pulumi up -y
+      - name: Tag the deployment
+        uses: Virtual-Finland-Development/automatic-release-action@v1.0
+        if: ${{ inputs.environment == 'staging' }}
+        with:
+          environment: ${{ inputs.environment }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates a release tag from successful staging deployments: https://virtualfindev.atlassian.net/jira/software/projects/VFD/boards/3?selectedIssue=VFD-159